### PR TITLE
Fix template literal syntax in googleAuthCallback redirect URL

### DIFF
--- a/packages/Backend/controllers/auth.Controller.js
+++ b/packages/Backend/controllers/auth.Controller.js
@@ -147,7 +147,7 @@ const googleAuthCallback = (req, res, next) => {
       // }
       if (user.tempToken) {
         return res.redirect(
-          "http://localhost:5174/google-signup?token=${user.tempToken}"
+          `http://localhost:5174/google-signup?token=${user.tempToken}`
         );
       }
       createSendToken_V2(user, 201, res);


### PR DESCRIPTION
Correct the syntax for the template literal in the redirect URL of the googleAuthCallback function.