### PR TITLE
Refactor invite API routes to simplify URLs and remove unused methods

### DIFF
--- a/API_Documentation.json
+++ b/API_Documentation.json
@@ -449,43 +449,30 @@
   "InviteAPI ": {
     "get All Invites For Sender": {
       "method": "GET",
-      "url": "http://localhost:9999/depiV1/users/:userID/projects/:projectID/invite/sender"
+      "url": "http://localhost:9999/depiV1/users/:userID/invite/sender"
     },
     "get All Invites For Receiver": {
       "method": "GET",
-      "url": "http://localhost:9999/depiV1/users/:userID/projects/:projectID/invite/receiver"
+      "url": "http://localhost:9999/depiV1/users/:userID/invite/receiver"
     },
     "search Users For Invite": {
       "method": "GET",
-      "url": "http://localhost:9999/depiV1/users/:userID/projects/:projectID/invite/search",
+      "url": "http://localhost:9999/depiV1/users/:userID/invite/search",
       "query": {
         "username": "Example_20"
       }
     },
-    "get One Invite": {
-      "method": "GET",
-      "url": "http://localhost:9999/depiV1/users/:userID/projects/:projectID/invite/:inviteID"
-    },
     "delete Invite": {
       "method": "DELETE",
-      "url": "http://localhost:9999/depiV1/users/:userID/projects/:projectID/invite/:inviteID"
-    },
-    "update Invite": {
-      "method": "PATCH",
-      "url": "http://localhost:9999/depiV1/users/:userID/projects/:projectID/invite/:inviteID",
-      "body": {
-        "username": "Example_20",
-        "projectId": "projectID",
-        "roleId": "roleID"
-      }
+      "url": "http://localhost:9999/depiV1/users/:userID/invite/:inviteID"
     },
     "decline Invite": {
       "method": "POST",
-      "url": "http://localhost:9999/depiV1/users/:userID/projects/:projectID/invite/:inviteID/decline"
+      "url": "http://localhost:9999/depiV1/users/:userID/invite/:inviteID/decline"
     },
     "accept Invite": {
       "method": "POST",
-      "url": "http://localhost:9999/depiV1/users/:userID/projects/:projectID/invite/:inviteID/accept"
+      "url": "http://localhost:9999/depiV1/users/:userID/invite/:inviteID/accept"
     },
     "send Invite": {
       "method": "POST",

--- a/packages/Backend/app/controllers/invite.Controller.js
+++ b/packages/Backend/app/controllers/invite.Controller.js
@@ -164,8 +164,6 @@ const acceptInvite = catchAsync(async (req, res, next) => {
 const getAllInvitesForReceiver = FC.getAll(Invite, "receiver");
 const getAllInvitesForSender = FC.getAll(Invite, "sender");
 
-const getOneInvite = FC.getOne(Invite);
-const updateInvite = FC.updateOne(Invite);
 const deleteInvite = FC.deleteOne(Invite);
 
 module.exports = {
@@ -174,8 +172,6 @@ module.exports = {
   acceptInvite,
   getAllInvitesForSender,
   getAllInvitesForReceiver,
-  getOneInvite,
-  updateInvite,
   deleteInvite,
   searchUsersForInvite,
 };

--- a/packages/Backend/routes/invite.Route.js
+++ b/packages/Backend/routes/invite.Route.js
@@ -18,10 +18,6 @@ router.get("/search", IC.searchUsersForInvite);
 
 router.post("/sendInvite", IC.sendInvite);
 
-router
-  .route("/:id")
-  .get(IC.getOneInvite)
-  .patch(IC.updateInvite)
-  .delete(IC.deleteInvite);
+router.delete("/:id", IC.deleteInvite);
 
 module.exports = router;


### PR DESCRIPTION
Simplify invite API routes by eliminating the project ID from URLs and removing unused controller methods, streamlining the invite management process.