### PR TITLE
Refactor sendInvite to check project membership and enforce username format

### DIFF
--- a/packages/Backend/app/controllers/invite.Controller.js
+++ b/packages/Backend/app/controllers/invite.Controller.js
@@ -57,13 +57,14 @@ const sendInvite = catchAsync(async (req, res, next) => {
       .json({ status: "fail", message: "Project not found" });
   }
 
-  if (
-    !project.members.user.name ||
-    project.members.user.name.toString() !== senderName
-  ) {
+  const isMember = project.members.some(
+    (member) => member.user.name.toString() === senderName
+  );
+
+  if (!isMember) {
     return res.status(403).json({
       status: "fail",
-      message: "You are not the project owner",
+      message: "You are not a project member",
     });
   }
 

--- a/packages/Backend/app/controllers/invite.Controller.js
+++ b/packages/Backend/app/controllers/invite.Controller.js
@@ -57,17 +57,6 @@ const sendInvite = catchAsync(async (req, res, next) => {
       .json({ status: "fail", message: "Project not found" });
   }
 
-  const isMember = project.members.some(
-    (member) => member.user.name.toString() === senderName
-  );
-
-  if (!isMember) {
-    return res.status(403).json({
-      status: "fail",
-      message: "You are not a project member",
-    });
-  }
-
   const isAlreadyMember = project.members.some(
     (member) => member.user.toString() === receiverId
   );

--- a/packages/Backend/app/models/user.Model.js
+++ b/packages/Backend/app/models/user.Model.js
@@ -24,6 +24,9 @@ const userSchema = new mongoose.Schema({
     type: String,
     required: true,
     unique: true,
+    match: [
+      /^(?=.{3,30}$)(?!.*[_.]{2})[a-zA-Z0-9](?:[a-zA-Z0-9._]*[a-zA-Z0-9])?$/,
+    ],
   },
   email: {
     type: String,


### PR DESCRIPTION
Update the `sendInvite` function to verify if a user is a project member instead of the owner. Additionally, enforce a specific format for usernames in the user schema.