### PR TITLE
Update password fields in API documentation for consistency

### DIFF
--- a/API_Documentation.json
+++ b/API_Documentation.json
@@ -80,9 +80,9 @@
       "method": "PATCH",
       "url": "http://localhost:9999/depiV1/users/updateMyPassword",
       "body": {
-        "currentPassword": "password",
-        "newPassword": "password",
-        "newPasswordConfirmation": "password"
+        "passwordCurrent": "password",
+        "password": "password",
+        "passwordConfirmation": "password"
       }
     },
     "Remove User Image": {


### PR DESCRIPTION
Revise the API documentation to ensure uniformity in the naming of password fields.