### PR TITLE
Fix typo in updateOne function and correct folder name for uploads

### DIFF
--- a/packages/Backend/app/controllers/Factory.Controller.js
+++ b/packages/Backend/app/controllers/Factory.Controller.js
@@ -38,13 +38,13 @@ const deleteOne = (Model, filterField) =>
     });
   });
 //________________________________________________________________________
-const updateOne = (Model, foledrName, fieldName) =>
+const updateOne = (Model, folderName = "", fieldName) =>
   catchAsync(async (req, res, next) => {
     if (req.files && req.files.length > 0) {
       const uploadPromises = req.files.map((file) =>
         cloudinary.uploader.upload(file.path, {
           resource_type: "auto",
-          folder: foledrName,
+          folder: folderName,
         })
       );
       const uploadedImages = await Promise.all(uploadPromises);


### PR DESCRIPTION
Correct the parameter name in the updateOne function and ensure the proper folder name is used for image uploads.