### PR TITLE
Fix URL for verify-otp endpoint in API documentation

### DIFF
--- a/API_Documentation.json
+++ b/API_Documentation.json
@@ -23,7 +23,7 @@
     },
     "verify-otp": {
       "method": "POST",
-      "url": "http://localhost:9999/depiV1/users/verify-otp",
+      "url": "http://localhost:9999/depiV1/users/verifyotp",
       "body": {
         "otp": "123456"
       }


### PR DESCRIPTION
Correct the URL for the verify-otp endpoint in the API documentation to ensure accurate usage.